### PR TITLE
fix: Error when scanning and connecting to a device #8

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ connected to and paths subscribed to during runtime.
 
 ## Firmware Installation
 
-For this CLI, the MoveSense devices require the `gatt-sensordata-app` firmware.
+For this CLI, the MoveSense devices require the `gatt-sensordata-app` firmware or the `default-firmware` version >=2.3.
 
 Official instructions for firmware update can be found here:
 - [MoveSense Firmware Installation Guide](https://www.movesense.com/docs/test_env/esw/dfu_update/)

--- a/src/cli/movesense_cli.py
+++ b/src/cli/movesense_cli.py
@@ -83,12 +83,12 @@ class MovesenseCLI:
 
         try:
             while True:
-                logger.info("Select the device to configure. 'return' to exit back to main menu.")
+                logger.info("Select the device to configure. '10' to exit back to main menu.")
                 self.device_manager.show_connected_devices()
 
                 choice = input()
 
-                if choice == "return":
+                if choice == "10":
                     raise KeyboardInterrupt
                 selected_device = None
                 # If choice based on MAC (MAC address regex)
@@ -96,6 +96,8 @@ class MovesenseCLI:
                     selected_device = next((device for device in self.device_manager.connected_devices
                                             if device.device.address.lower() == choice.lower()),
                                            None)
+                    # Show configuration menu
+                    self.start_single_device_configuration(selected_device)
                 # If choice based on list id
                 else:
                     try:
@@ -105,14 +107,13 @@ class MovesenseCLI:
                         logger.error(f"Invalid input. Please enter a valid list-id as an integer or a MAC address.")
                     except IndexError:
                         logger.error(f"Invalid list-id '{index + 1}'. List-id out of range.")
-
-                # Show configuration menu
-                self.start_single_device_configuration(selected_device)
+                    # Show configuration menu
+                    self.start_single_device_configuration(selected_device, index)
 
         except KeyboardInterrupt:
             logger.info("Exiting the device menu")
 
-    def start_single_device_configuration(self, device):
+    def start_single_device_configuration(self, device, device_index=None):
         try:
             while True:
                 logger.info("What would you like to do?")
@@ -144,8 +145,8 @@ class MovesenseCLI:
                         # Subscription path determines response id (fixed for ease of use), "Meas", the sensor type,
                         # and sampling rate
                         sensor = MovesenseSensor(sensor_full, fs)
-
-                        self.config["devices"][device.address]["paths"].append(
+                        device_selected = device.address if device_index is None else device_index
+                        self.config["devices"][device_selected]["paths"].append(
                             f"Meas/{sensor.sensor_type.value}/{sensor.sampling_rate.value}")
                         self.device_manager.subscribe_to_sensor(device, sensor)
                     except ValueError:

--- a/src/movesense/movesense_device_manager.py
+++ b/src/movesense/movesense_device_manager.py
@@ -75,7 +75,9 @@ class MovesenseDeviceManager:
         devices = self.run_coroutine_sync(BleakScanner.discover(timeout=5.0))
         found_devices = []
         for device in devices:
-            if show_all or (device.name is not None and "movesense" in device.name.lower()):
+            if device.name is None:
+                continue
+            if show_all or "movesense" in device.name.lower():
                 found_devices.append(device)
                 if logging:
                     logger.info(f"Found device: {len(found_devices)}. {device.name} - {device.address}")
@@ -118,7 +120,7 @@ class MovesenseDeviceManager:
 
         self.run_coroutine_sync(rename_coroutine(device, new_name))
 
-    def subsribe_to_sensor(self, device, sensor):
+    def subscribe_to_sensor(self, device, sensor):
         async def subsribe_coroutine(device, sensor):
             # Allow path creation of the sensor.
             if isinstance(sensor, str):


### PR DESCRIPTION
- Error if BLE device nearby advertise empty name
- Mention correct Movesense firmware version in the Readme
- Indexing issue in device selection for configuration
- Typo in function name definition